### PR TITLE
Fixes downloading by adding user agent header of company name + email

### DIFF
--- a/DataProcessing/SECDataDownloader.cs
+++ b/DataProcessing/SECDataDownloader.cs
@@ -66,11 +66,13 @@ namespace QuantConnect.DataProcessing
             // We will be rate limited from the SEC website if we don't identify ourselves via User-Agent.
             // Also we use a global HttpClient instance to enable HTTP keep-alive, which will improve performance
             // and also reduce the chances of being rate-limited (plus, this is recommended practice).
+            var companyName = Environment.GetEnvironmentVariable("SEC_UA_COMPANY_NAME");
+            var companyEmail = Environment.GetEnvironmentVariable("SEC_UA_COMPANY_EMAIL");
 
             using (var client = new HttpClient())
             {
-                var userAgent = new ProductInfoHeaderValue("User-Agent", $"QC-SEC-{Guid.NewGuid()}");
-                client.DefaultRequestHeaders.UserAgent.Add(userAgent);
+                var userAgent = string.Join(" ", companyName, companyEmail);
+                client.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", userAgent);
                 
                 Directory.CreateDirectory(Path.Combine(rawDestination, "indexes"));
 

--- a/DataProcessing/SECDataDownloader.cs
+++ b/DataProcessing/SECDataDownloader.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using QuantConnect.Configuration;
 using QuantConnect.DataSource;
 using QuantConnect.Logging;
 using QuantConnect.Util;
@@ -66,8 +67,17 @@ namespace QuantConnect.DataProcessing
             // We will be rate limited from the SEC website if we don't identify ourselves via User-Agent.
             // Also we use a global HttpClient instance to enable HTTP keep-alive, which will improve performance
             // and also reduce the chances of being rate-limited (plus, this is recommended practice).
-            var companyName = Environment.GetEnvironmentVariable("SEC_UA_COMPANY_NAME");
-            var companyEmail = Environment.GetEnvironmentVariable("SEC_UA_COMPANY_EMAIL");
+            var companyName = Config.Get("sec-user-agent-company-name");
+            var companyEmail = Config.Get("sec-user-agent-company-email");
+
+            if (string.IsNullOrEmpty(companyName))
+            {
+                throw new ArgumentException("The SEC requires a company name to download data using automation. Please edit `config.json` and add a `sec-user-agent-company-name` entry with your company name");
+            }
+            if (string.IsNullOrEmpty(companyEmail))
+            {
+                throw new ArgumentException("The SEC requires a company email contact to download data using automation. Please edit `config.json` and add a `sec-user-agent-company-email` entry with your company email address");
+            }
 
             using (var client = new HttpClient())
             {


### PR DESCRIPTION
Following the SEC's requirements for using their website via a bot, a company name and email must be provided. This improves stability of downloading and should allow for resuming SEC updates.

Adding the user-agent header using `TryAddWithoutValidation` because the standard library implementation of `Add(...)` apparently doesn't allow for `@` characters in the user agent, but the SEC requires it and handles it properly.