### PR TITLE
Removes Dependency to "Rank And File" data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    container:
-        image: quantconnect/lean:foundation
-    steps:
-      - uses: actions/checkout@v2
+
+    steps:    
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Free space
+        run: df -h && rm -rf /opt/hostedtoolcache* && df -h
+
+      - name: Pull Foundation Image
+        uses: addnab/docker-run-action@v3
+        with:
+          image: quantconnect/lean:foundation
 
       - name: Checkout Lean Same Branch
         id: lean-same-branch

--- a/DataProcessing/DataProcessing.csproj
+++ b/DataProcessing/DataProcessing.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
       <PackageReference Include="QuantConnect.Common" Version="2.5.*" />
+      <PackageReference Include="QuantConnect.Lean.Engine" Version="2.5.*" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     </ItemGroup>
 

--- a/DataProcessing/SECDataDownloader.cs
+++ b/DataProcessing/SECDataDownloader.cs
@@ -313,9 +313,6 @@ namespace QuantConnect.DataProcessing
                 var cikTickerListPath = Path.Combine(rawDestination, "cik-ticker-mappings.txt");
                 var cikTickerListTempPath = $"{cikTickerListPath}.tmp";
 
-                var cikRankAndFileTickerListPath = Path.Combine(rawDestination, "cik-ticker-mappings-rankandfile.txt");
-                var cikRankAndFileTickerListTempPath = $"{cikRankAndFileTickerListPath}.tmp";
-
                 // Download master list of CIKs from SEC website and store on disk
                 var cikLookupPath = Path.Combine(rawDestination, "cik-lookup-data.txt");
                 var cikLookupTempPath = $"{cikLookupPath}.tmp";
@@ -336,21 +333,6 @@ namespace QuantConnect.DataProcessing
                             File.WriteAllBytes(cikTickerListTempPath, tickerCikMappingsBytes);
                             File.Move(cikTickerListTempPath, cikTickerListPath);
                             File.Delete(cikTickerListTempPath);
-                        }
-
-                        if (!File.Exists(cikRankAndFileTickerListPath))
-                        {
-                            _indexGate.WaitToProceed();
-
-                            Log.Trace(
-                                "SECDataDownloader.Download(): Downloading ticker-CIK mappings list from rankandfile");
-                            var tickerCikMappingsBytes = client
-                                .GetByteArrayAsync("http://rankandfiled.com/static/export/cik_ticker.csv")
-                                .SynchronouslyAwaitTaskResult();
-
-                            File.WriteAllBytes(cikRankAndFileTickerListTempPath, tickerCikMappingsBytes);
-                            File.Move(cikRankAndFileTickerListTempPath, cikRankAndFileTickerListPath);
-                            File.Delete(cikRankAndFileTickerListTempPath);
                         }
 
                         if (!File.Exists(cikLookupPath))

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -19,7 +19,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="protobuf-net" Version="3.0.29" />
+    <PackageReference Include="protobuf-net" Version="3.1.33" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
http://rankandfiled.com/static/export/cik_ticker.csv is no longer available so we will use QuantConnect CIK database. It only adds a few entries on top of https://www.sec.gov/include/ticker.txt but improves coverage.

Update the hard-coded holidays with dates from the MHDB.