### PR TITLE
Run CI on self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,20 +6,19 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: self-hosted
+    container:
+        image: quantconnect/lean:foundation
+        options: --cpus 12 --memory 12g
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Liberate disk space
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: true
-          large-packages: false
-          docker-images: false
-          swap-storage: false
 
       - name: Checkout Lean Same Branch
         id: lean-same-branch
@@ -40,15 +39,12 @@ jobs:
       - name: Move Lean
         run: mv Lean ../Lean
 
-      - uses: addnab/docker-run-action@v3
-        with:
-          image: quantconnect/lean:foundation
-          options: --workdir /__w/Lean.DataSource.SEC/Lean.DataSource.SEC -v /home/runner/work:/__w
-          shell: bash
-          run: |
-            # BuildDataSource
-            dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
-            # BuildTests
-            dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
-            # Run Tests
-            dotnet test ./tests/bin/Release/net10.0/Tests.dll
+      - name: Run build and tests
+        run: |
+          # BuildDataSource
+          dotnet build ./QuantConnect.DataSource.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
+          # BuildTests
+          dotnet build ./tests/Tests.csproj /p:Configuration=Release /v:quiet /p:WarningLevel=1
+          # Run Tests
+          dotnet test ./tests/bin/Release/net10.0/Tests.dll
+


### PR DESCRIPTION
Mirrors QuantConnect/Lean#9540 (`c57fd18b`): build/test now runs on **self-hosted** runners inside a job-level `quantconnect/lean:foundation` container (`--cpus 12 --memory 12g`) instead of GitHub-hosted ubuntu + `addnab/docker-run-action`. Drops the disk-cleanup step and docker-run wrapper (build/test run as a normal step in the container; secrets via container `env`), and adds a `concurrency` group (cancel-in-progress). YAML validated; needs a runner to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)